### PR TITLE
[contactsd] Restrict toggle notebook visibility on account change. Contributes to JB#53398

### DIFF
--- a/plugins/calendar/cdcalendarcontroller.cpp
+++ b/plugins/calendar/cdcalendarcontroller.cpp
@@ -30,6 +30,7 @@ namespace {
     Sets the \a enabled status for all notebooks associated with the given
     account \a id.
 */
+static const QByteArray VISIBILITY_CHANGED_FLAG("hidden_by_account");
 void updateNotebooks(AccountId id, bool enabled)
 {
     mKCal::ExtendedCalendar::Ptr calendar = mKCal::ExtendedCalendar::Ptr(
@@ -44,8 +45,13 @@ void updateNotebooks(AccountId id, bool enabled)
         AccountId accountInt = accountStr.toULong(&ok);
         if (ok && accountInt == id) {
             bool visible = notebook->isVisible();
-            if (visible != enabled) {
-                notebook->setIsVisible(enabled);
+            if (!enabled && visible) {
+                notebook->setIsVisible(false);
+                notebook->setCustomProperty(VISIBILITY_CHANGED_FLAG, QString::fromLatin1("true"));
+                storage->updateNotebook(notebook);
+            } else if (enabled && !visible && !notebook->customProperty(VISIBILITY_CHANGED_FLAG).isEmpty()) {
+                notebook->setIsVisible(true);
+                notebook->setCustomProperty(VISIBILITY_CHANGED_FLAG, QString());
                 storage->updateNotebook(notebook);
             }
         }


### PR DESCRIPTION
@flypig, you may remember that discussion : we decided to base the notebook visibility on the Notebook::setIsVisible() routine only and created a plugin in contactsd to change visibility on account enable change.

But as we noticed earlier, the callback on enable change is called in fact each time `syncAndBlock()` is called, so each time a modification (even not related to enable status) is made to the account.

From https://forum.sailfishos.org/t/calendar-bug-for-disabled-calendars-in-3-4-ea/2563/17 it seems that we still have issues in the Google sync plugin. But grepping for `setIsVisible` in the plugin don't return any match. So the only logical possibility I can think of is this plusgin in case the Google plugin is calling `syncAndBlock` or an equivalent one.

The approach I propose here is based on the assumption that the callback here can be triggered at anytime, even for no enable changes. If the enable is false, then the notebook should be hidden unconditionnaly. When doing so, we set a flag on the notebook to remember that it was hidden by the account change. When the enable is visible we then switch on only the notebooks with the flag.

It has a minor drawback :
- the notebook becomes hidden by an account disable and get the flag,
- the user still would like to see the notebook and switch it on,
- then changes his mind and switch it off,
- later on he enables again the account.
In theory, the last user choice was off, so it should be kept off. But the patch logic cannot cope with this case. I think it's a corner one.

I still didn't check on device if it's working or not. I'll see if I have time today. I'm not using any Google calendar, so it may take some time to set it up.